### PR TITLE
Fix curl command to purge jsdelivr CDN cache

### DIFF
--- a/.github/workflows/purge-cdn.yml
+++ b/.github/workflows/purge-cdn.yml
@@ -28,7 +28,7 @@ jobs:
           for file in "${FILES[@]}"; do
             URL="https://purge.jsdelivr.net/gh/${{ github.repository }}@main/$file"
             echo "Purging: $file"
-            RESPONSE=$(curl -fsSw "\n%{http_code}" -X POST "$URL")
+            RESPONSE=$(curl -fsSw "\n%{http_code}" "$URL")
             HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
             BODY=$(echo "$RESPONSE" | head -n-1)
             if [ "$HTTP_CODE" -eq 200 ]; then


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Switches the CDN purge request in the GitHub Actions workflow from POST to a default GET to align with jsDelivr’s endpoint behavior, improving reliability. 🚀

### 📊 Key Changes
- Updated `.github/workflows/purge-cdn.yml`:
  - Removed `-X POST` from the `curl` command used to purge jsDelivr (`curl -fsSw "\n%{http_code}" "$URL"`).
  - Keeps response handling intact to check HTTP status and body.

### 🎯 Purpose & Impact
- Ensures CDN purge requests succeed by using the correct HTTP method (avoids 405/4xx errors). ✅
- Improves CI/CD reliability for cache invalidation, ensuring users get the latest assets quickly. ⚡
- No impact on runtime code or user-facing APIs; change is limited to the CI workflow. 🔒