### PR TITLE
Update purge-cdn.yml

### DIFF
--- a/.github/workflows/purge-cdn.yml
+++ b/.github/workflows/purge-cdn.yml
@@ -26,7 +26,7 @@ jobs:
           )
           echo "Purging jsdelivr CDN cache for ${{ github.repository }}..."
           for file in "${FILES[@]}"; do
-            URL="https://purge.jsdelivr.net/gh/${{ github.repository }}@main/$file"
+            URL="https://purge.jsdelivr.net/gh/${{ github.repository }}@master/$file"
             echo "Purging: $file"
             RESPONSE=$(curl -fsSw "\n%{http_code}" "$URL")
             HTTP_CODE=$(echo "$RESPONSE" | tail -n1)


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Switches the jsDelivr CDN purge workflow to target the `master` branch instead of `main` to ensure cache invalidation works correctly. 🚀

### 📊 Key Changes
- Updated GitHub Actions workflow `.github/workflows/purge-cdn.yml`:
  - Changed purge URL branch segment from `@main` to `@master` for jsDelivr cache invalidation.

### 🎯 Purpose & Impact
- Ensures CDN cache purges hit the correct branch, preventing stale files from being served. ⚡
- Improves reliability of asset updates after merges/releases.
- No runtime or API changes; impact is limited to CI/CD and CDN behavior.
- If the default branch is `master`, this fixes broken purges; if not, it could misdirect purges—worth confirming default branch settings. ✅