### PR TITLE
Delete .prettierrc

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -22,7 +22,6 @@ class UltralyticsChat {
         logoUrl: d(config.branding, "logoUrl", "https://www.ultralytics.com"),
         pillText: d(config.branding, "pillText", "Ask AI"),
       },
-
       theme: {
         primary: d(config.theme, "primary", "#042AFF"),
         dark: d(config.theme, "dark", "#111F68"),


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Removes the repo-specific Prettier configuration, reverting to default or external formatting settings. ✨

### 📊 Key Changes
- 🗑️ Deleted the `.prettierrc` file that set `printWidth` to 120 characters.

### 🎯 Purpose & Impact
- 🔄 Formatting will now follow Prettier’s default configuration or any globally defined project settings.
- 🤝 Reduces tool-specific configuration in this repo, which can simplify setup for contributors using standard editor/Prettier defaults.
- ⚠️ Minor risk of formatting diffs in future commits if contributors’ environments previously relied on the custom `printWidth` setting.