### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: false
 


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions CI workflow to use `astral-sh/setup-uv@v8` instead of `@v7`, keeping the repository’s automation up to date.

### 📊 Key Changes
- Upgraded the CI workflow dependency in `.github/workflows/ci.yml`
- Replaced `astral-sh/setup-uv@v7` with `astral-sh/setup-uv@v8`
- No application code or user-facing features were changed

### 🎯 Purpose & Impact
- Improves CI maintenance by aligning with the newer version of the `setup-uv` GitHub Action 🛠️
- May provide better reliability, compatibility, or upstream fixes in automated test environments ✅
- Low-risk change since it only affects GitHub Actions setup, not runtime behavior for end users 📦