### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/tag.yml

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: uv pip install --system ultralytics-actions


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/tag.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions workflow to use a newer version of `astral-sh/setup-uv`, improving CI maintenance and keeping the tagging pipeline up to date.

### 📊 Key Changes
- Updated the GitHub Actions step in `.github/workflows/tag.yml`
- Changed `astral-sh/setup-uv` from `@v7` to `@v8`
- No application code or model behavior was changed—this is a workflow/infrastructure update only 🛠️

### 🎯 Purpose & Impact
- Keeps the repository’s automation aligned with the latest supported version of the `setup-uv` GitHub Action
- May improve reliability, compatibility, and maintainability of the tag/release workflow 🚀
- Reduces risk of using outdated CI tooling over time
- Has little to no direct impact on end users, but helps maintain smoother repository operations behind the scenes 👍