### PR TITLE
Bump astral-sh/setup-uv to v8 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: false
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: uv pip install --system ultralytics-actions


### PR DESCRIPTION
Bump astral-sh/setup-uv to v8 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions `setup-uv` step from `v7` to `v8` in CI and tag workflows to keep automation current and reliable.

### 📊 Key Changes
- Upgraded `astral-sh/setup-uv` from `@v7` to `@v8` in `.github/workflows/ci.yml`
- Upgraded `astral-sh/setup-uv` from `@v7` to `@v8` in `.github/workflows/tag.yml`
- No application code or model behavior was changed—this is a workflow and infrastructure maintenance update only 🛠️

### 🎯 Purpose & Impact
- Helps keep GitHub Actions workflows aligned with the latest supported version of the `setup-uv` action ✅
- May improve CI and release-tagging stability, compatibility, and long-term maintainability 🚀
- Reduces the risk of issues tied to older action versions, such as deprecations or missed fixes 🔒
- Has little to no direct impact on end users, but benefits contributors and maintainers through smoother automation 👩‍💻👨‍💻