### PR TITLE
Fix invalid setup-uv action version

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv pip install --system ultralytics-actions


### PR DESCRIPTION
## Summary
- change `astral-sh/setup-uv` from `@v8` to `@v7` in the tag workflow
- fix the workflow reference to an action version that exists

## Testing
- `rg -n --hidden --no-ignore 'astral-sh/setup-uv@v8' /Users/glennjocher/PycharmProjects`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small CI update by changing the GitHub Action used to install `uv` in the tag workflow from `astral-sh/setup-uv@v8` to `@v7`.

### 📊 Key Changes
- Downgraded the `uv` setup action in `.github/workflows/tag.yml`
- Changed:
  - `astral-sh/setup-uv@v8` → `astral-sh/setup-uv@v7`
- No application code or model behavior was modified; this only affects the repository’s GitHub Actions workflow

### 🎯 Purpose & Impact
- ✅ Likely improves workflow stability or compatibility if `@v8` introduced issues
- 🛠️ Helps ensure the tag/release automation continues to run reliably
- 📦 Reduces risk of CI failures during dependency installation in the tagging pipeline
- 👥 No direct impact on end users of the package, but it can improve maintainer and release process reliability