### PR TITLE
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           python -m pytest tests -v --cov=./ --cov-report=xml:pytest-coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./pytest-coverage.xml, # optional (default = coverage.xml)


### PR DESCRIPTION
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions CI workflow to use `codecov/codecov-action@v7` instead of `@v6` for uploading test coverage reports.

### 📊 Key Changes
- 🛠️ Updated the Codecov GitHub Action in `.github/workflows/ci.yml`
- ⬆️ Changed `codecov/codecov-action@v6` to `codecov/codecov-action@v7`
- ✅ Kept the existing coverage upload configuration, including the coverage token and report file path

### 🎯 Purpose & Impact
- 🚀 Keeps the repository’s CI pipeline aligned with the latest Codecov GitHub Action version
- 🔒 May improve security, reliability, and compatibility by using a newer maintained action release
- 🧰 Helps ensure coverage reporting continues to work smoothly in automated testing workflows
- 👥 Minimal user-facing impact, but beneficial for maintainers managing CI and project health