### PR TITLE
Fix Codecov OIDC upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: CI
 
 permissions:
   contents: read # Read code in PRs
+  id-token: write # Required for Codecov OIDC uploads
 
 on:
   push:
@@ -52,5 +53,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./pytest-coverage.xml, # optional (default = coverage.xml)
+          files: ./pytest-coverage.xml
+          disable_search: true
+          fail_ci_if_error: true
+          plugins: noop
+          use_oidc: true

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/ultralytics/llm/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/llm/actions/workflows/ci.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/llm/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/llm/actions/workflows/format.yml)
-[![codecov](https://codecov.io/gh/ultralytics/llm/graph/badge.svg?token=CODECOV_TOKEN)](https://codecov.io/gh/ultralytics/llm)
+[![codecov](https://codecov.io/github/ultralytics/llm/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/llm)
 [![Vercel Deploy](https://deploy-badge.vercel.app/vercel/chatjs-ultralytics?root=examples%2Fweb%2Fdemo)](https://chatjs-ultralytics.vercel.app/examples/web/demo)
 [![jsDelivr hits](https://data.jsdelivr.com/v1/package/gh/ultralytics/llm/badge?style=rounded)](https://www.jsdelivr.com/package/gh/ultralytics/llm)
 


### PR DESCRIPTION
## Summary
- update the README Codecov badge to the public app/codecov URLs
- switch Codecov upload from secret token auth to GitHub OIDC
- make Codecov upload explicit and fail loudly

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'\n- actionlint .github/workflows/ci.yml\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR modernizes Codecov integration in CI by switching to OIDC-based authentication and updates the README coverage badge to a cleaner, token-free Codecov link.

### 📊 Key Changes
- Added `id-token: write` permission in the GitHub Actions CI workflow to support Codecov uploads via OIDC.
- Updated the Codecov upload step to:
  - remove the secret token requirement
  - use `use_oidc: true` for authentication
  - explicitly upload `./pytest-coverage.xml`
  - set `disable_search: true` to avoid scanning for other coverage files
  - enable `fail_ci_if_error: true` so CI fails if coverage upload breaks
  - set `plugins: noop` for a simpler upload configuration
- Refreshed the README Codecov badge:
  - removed the tokenized badge URL
  - switched to a branch-specific badge for `main`
  - updated the link to the current Codecov app URL

### 🎯 Purpose & Impact
- 🚀 Improves CI security by removing dependence on a stored `CODECOV_TOKEN` and using GitHub’s OIDC authentication instead.
- 🛡️ Makes coverage reporting more reliable by failing CI when Codecov upload errors occur, helping catch reporting issues early.
- 🧹 Simplifies maintenance with a more explicit and predictable Codecov configuration.
- 📈 Improves project presentation in the README with a cleaner, public-facing coverage badge and updated Codecov link.
- 👥 Benefits both maintainers and contributors by making the CI pipeline easier to manage and more transparent.