### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## 🎯 Current Status
 
-> **⚠️ Experimental Development**: The chat widget ships as a CDN-ready `chat.min.js` bundle and as part of the `ultralytics-llm` Python package published on PyPI. Track tagged releases for production deployments and reserve `@main` for testing nightly changes.
+> **⚠️ Experimental Development**: The chat widget ships as a CDN-ready `chat.min.js` bundle. Track tagged releases for production deployments and reserve `@main` for testing nightly changes.
 >
 > **Ecosystem:** This repo hosts both the in-browser chat widget and the Python scaffolding we use for backend workflows. The widget is production ready, while the Python client remains a lightweight placeholder until the managed API is released.
 
@@ -33,7 +33,7 @@ Load the chat widget via [jsDelivr CDN](https://www.jsdelivr.com/package/gh/ultr
 <script src="https://cdn.jsdelivr.net/gh/ultralytics/llm@latest/js/chat.min.js"></script>
 
 <!-- Specific version (guaranteed stability) -->
-<script src="https://cdn.jsdelivr.net/gh/ultralytics/llm@v0.2.1/js/chat.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/ultralytics/llm@v0.2.12/js/chat.min.js"></script>
 
 <!-- Main branch (experimental, for testing) -->
 <script src="https://cdn.jsdelivr.net/gh/ultralytics/llm@main/js/chat.min.js"></script>
@@ -49,7 +49,7 @@ Load the chat widget via [jsDelivr CDN](https://www.jsdelivr.com/package/gh/ultr
 **Versioning Strategy:**
 
 - `@latest` - Always points to the newest tagged release (cache purged on new releases)
-- `@v0.0.1` - Specific version tags (permanent cache, high reliability)
+- `@v0.2.12` - Specific version tags (permanent cache, high reliability)
 - `@main` - Latest development code (12-hour cache, auto-purged on push)
 
 > **Note**: For production, use `@latest` or pin to a specific version tag. The `@main` branch is for testing and may contain breaking changes.


### PR DESCRIPTION
## Summary
- fixes stale or broken README links
- corrects outdated README claims or examples
- polishes wording where it improves clarity and professionalism

## Validation
- git diff --check
- README links/examples checked against repository source and current external sources

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR updates the README to clarify distribution details for the chat widget and refreshes the documented CDN version from `v0.2.1` to `v0.2.12`.

### 📊 Key Changes
- Removed the README claim that the chat widget is shipped as part of the `ultralytics-llm` Python package on PyPI.
- Clarified that the widget is distributed as a CDN-ready `chat.min.js` bundle, while Python support remains lightweight placeholder scaffolding for backend workflows.
- Updated the example pinned CDN version in the script tag from `@v0.2.1` to `@v0.2.12`.
- Updated the versioning strategy example to use `@v0.2.12` instead of the older generic `@v0.0.1`.

### 🎯 Purpose & Impact
- ✅ Makes the documentation more accurate by aligning it with the current release and distribution model.
- 🚀 Helps users adopt a newer stable widget version by showing the latest recommended pinned CDN tag.
- 🧭 Reduces confusion for developers about what is production-ready today: the browser widget is ready, while the Python client is not yet a full managed API offering.
- 🔒 Encourages better deployment practices by reinforcing the difference between stable tagged releases and the experimental `@main` branch.