### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.9", "3.13"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/minify.yml
+++ b/.github/workflows/minify.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref || github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets._GITHUB_TOKEN }}


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates GitHub Actions workflows to use `actions/checkout@v7` instead of `@v6`, keeping repository automation current and more maintainable.

### 📊 Key Changes
- Updated `actions/checkout` from `@v6` to `@v7` in the main CI workflow.
- Updated `actions/checkout` from `@v6` to `@v7` in the minify workflow.
- Updated `actions/checkout` from `@v6` to `@v7` in the tag/release workflow.
- No application code or user-facing features were changed; this is a CI/CD infrastructure update only. 🛠️

### 🎯 Purpose & Impact
- Helps keep the repository’s GitHub Actions setup up to date with the latest supported checkout action. ✅
- Reduces maintenance risk by aligning automation workflows with newer action versions.
- May improve workflow reliability, compatibility, and long-term security in CI and release processes. 🔒
- Has little to no direct impact on end users, but benefits contributors and maintainers through healthier project automation. 🚀