### PR TITLE
Make Codecov upload best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,11 @@ jobs:
           python -m pytest tests -v --cov=./ --cov-report=xml:pytest-coverage.xml
 
       - name: Upload coverage to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           files: ./pytest-coverage.xml
           disable_search: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           plugins: noop
           use_oidc: true


### PR DESCRIPTION
## Summary\n- make the Codecov upload step non-blocking\n- keep existing coverage files, OIDC, flags, and plugins settings\n\n## Validation\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Makes Codecov coverage uploads non-blocking in CI to improve workflow reliability and reduce failed checks from external service issues 🚦

### 📊 Key Changes
- Added `continue-on-error: true` to the Codecov upload step ✅
- Changed `fail_ci_if_error` from `true` to `false` for the Codecov action 🛠️
- Keeps coverage report generation unchanged, still uploading `pytest-coverage.xml` when possible 📈

### 🎯 Purpose & Impact
- Prevents CI failures caused by Codecov upload errors, outages, or authentication issues 🌐
- Helps developers avoid blocked PRs when tests pass but coverage reporting fails 🚀
- Maintains test coverage visibility while making the pipeline more resilient and developer-friendly 🔍