### PR TITLE
Bump actions/setup-node from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/minify.yml
+++ b/.github/workflows/minify.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 


### PR DESCRIPTION
Bump actions/setup-node from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the GitHub Actions Node.js setup action to the latest major version in the minification workflow. ⚙️

### 📊 Key Changes

- Replaces `actions/setup-node@v6` with `actions/setup-node@v7`.
- Keeps the workflow on Node.js version 22.
- Applies the update specifically to the minification CI job.

### 🎯 Purpose & Impact

- Ensures the workflow uses the latest supported setup action improvements. 🚀
- May provide updated compatibility, performance, and security fixes from `actions/setup-node@v7`.
- No expected changes to application behavior or generated output; this is a CI maintenance update. ✅