### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
+      - uses: ultralytics/actions/setup-uv@main
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
 
       - name: Install dependencies
         run: uv pip install --system ultralytics-actions


### PR DESCRIPTION
## Summary
- replace all 2 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 2 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated GitHub Actions workflows to use Ultralytics’ shared `setup-uv` action for consistent Python package management. ⚙️

### 📊 Key Changes

- Replaced `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main` in:
  - The continuous integration workflow.
  - The tag and release workflow.
- Removed the previous explicit UV cache configuration from the CI workflow.

### 🎯 Purpose & Impact

- 🔄 Centralizes UV setup across Ultralytics repositories.
- 🧩 Improves consistency and maintainability of workflow configuration.
- 🚀 Allows shared improvements to the setup process to benefit this repository automatically.
- ✅ Keeps dependency installation and CI behavior otherwise unchanged.