### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -61,7 +61,7 @@ jobs:
           git push origin "${{ github.event.inputs.tag_name }}"
 
       - name: Set up Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates GitHub Actions to use `actions/setup-python@v7` for CI and release tagging workflows. ⚙️

### 📊 Key Changes

- Replaced `actions/setup-python@v6` with `actions/setup-python@v7` in:
  - The continuous integration workflow (`ci.yml`)
  - The tag and release workflow (`tag.yml`)
- No application code or model behavior was changed.

### 🎯 Purpose & Impact

- Keeps the repository’s automation aligned with the latest supported Python setup action. ✅
- Helps maintain reliable Python environment configuration across tests and release tasks.
- Users should see no direct runtime changes, while contributors may benefit from improved workflow maintenance and compatibility. 🚀