### PR TITLE
Document why Biome formatting is disabled

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,7 +28,7 @@ jobs:
           labels: true # Auto-label issues/PRs using AI
           python: true # Format Python with Ruff and docformatter
           prettier: true # Format YAML, JSON, Markdown, CSS
-          biome: false # Format JS/TS with Biome (auto-detected via biome.json)
+          biome: false # Enabling reformats js/chat.min.js unless biome.json excludes **/*.min.js — see PR description
           swift: false # Format Swift (requires macos-latest)
           spelling: true # Check spelling with codespell
           links: true # Check broken links with Lychee

--- a/examples/web/demo.html
+++ b/examples/web/demo.html
@@ -649,7 +649,14 @@ results[0].show()</code></pre>
 
     <footer class="footer">
       <span>Need help?</span>
-      <a href="#" onclick="openChat();return false;">Ask Ultralytics AI</a>
+      <a
+        href="#"
+        onclick="
+          openChat();
+          return false;
+        "
+        >Ask Ultralytics AI</a
+      >
     </footer>
 
     <!-- Chat client -->


### PR DESCRIPTION
Comment-only change to `.github/workflows/format.yml`. No behavior change — `biome` stays `false`.

This repo has a `biome.json` with the formatter enabled, so the setting reads like an oversight. It isn't: I tested enabling it, and the reason to leave it off (as configured today) is concrete.

### What happens with `biome: true` as-is

Ultralytics Actions runs `biome check --write --line-width=120 --max-diagnostics=1000 --diagnostic-level=error --unsafe .`. With Biome 2.5.5, the version now pinned in ultralytics/actions#847:

```
Checked 5 files in 51ms. Fixed 3 files.
Found 122 errors.
```

`js/chat.min.js` is reformatted — **1 line → 1184 lines, 58 KB → 71 KB**. The minified artifact gets expanded and committed by the bot. Prettier avoids this because its glob in `action.yml` excludes `**/*.min.js`; the Biome step passes `.` and relies on `biome.json`, which has no such exclusion.

### What it would take to enable

Adding the exclusion to `biome.json`:

```json
"files": {
  "ignoreUnknown": true,
  "includes": ["**", "!**/*.min.js", "!**/*.min.css"]
}
```

drops it to 4 files checked and 5 errors, leaves `chat.min.js` untouched, and produces a small, sane diff (13 insertions / 12 deletions across `js/chat.js` and `examples/web/demo.html` — mostly optional-chaining fixes from `--unsafe`).

The 5 remaining errors are not auto-fixable and would need code changes:

- `examples/web/demo.html` — `a11y/useSemanticElements`, `a11y/useButtonType`, `a11y/useValidAnchor`
- `js/chat.js` — `correctness/noConstructorReturn`

The Biome step is `continue-on-error: true`, so these would not fail CI, but they would be reported on every PR.

I kept this PR to the comment alone rather than making that call. Happy to open a follow-up that adds the exclusion and enables Biome if you want it on.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improved web demo formatting while preventing automated Biome formatting from modifying the minified chat client. ✨

### 📊 Key Changes
- Updated the formatting workflow comment to document why Biome remains disabled: it could reformat `js/chat.min.js`.
- Reformatted the “Ask Ultralytics AI” footer link in `examples/web/demo.html` for improved readability.
- Preserved the link’s existing behavior of opening the chat and preventing default navigation.

### 🎯 Purpose & Impact
- Keeps minified JavaScript files unchanged during automated formatting. 🛡️
- Improves HTML consistency and maintainability without changing user-facing functionality.
- Reduces the risk of unnecessary or potentially large formatting changes in CI.