### PR TITLE
Point pyproject Documentation URL at the repo API docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
 [project.urls]
 "Homepage" = "https://ultralytics.com"
 "Source" = "https://github.com/ultralytics/llm"
-"Documentation" = "https://docs.ultralytics.com"
+"Documentation" = "https://github.com/ultralytics/llm/blob/main/docs/API.md"
 "Bug Reports" = "https://github.com/ultralytics/llm/issues"
 
 [tool.setuptools]


### PR DESCRIPTION
`[project.urls] Documentation` pointed at `https://docs.ultralytics.com`, which has no page for this repo — `docs.ultralytics.com/llm` returns 404. Point it at `docs/API.md`, the repo's actual API reference for the widget and backend contracts.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the package metadata so the Documentation link points directly to the repository’s API documentation. 📚

### 📊 Key Changes

- Changed the `Documentation` URL in `pyproject.toml`.
- Replaced the general Ultralytics documentation site with [`docs/API.md`](https://github.com/ultralytics/llm/blob/main/docs/API.md).

### 🎯 Purpose & Impact

- 📖 Helps users quickly find documentation specific to the `ultralytics/llm` package.
- 🔗 Improves the accuracy of links shown on package indexes and project metadata.
- ✅ No changes to runtime behavior, APIs, or model functionality.