### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: weekly
-      time: "04:00"
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-
   - package-ecosystem: github-actions
     directory: "/.github/workflows"
     schedule:

--- a/.github/workflows/minify.yml
+++ b/.github/workflows/minify.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   minify:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event.pull_request.head.repo.full_name == github.repository # Fork PRs cannot receive pushed commits
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Aligns \`.github/\` with the reference configuration used in \`ultralytics/sdk\`, \`skills\`, \`openapi\` and \`lite\`.

- \`dependabot.yml\`: drop the \`pip\` ecosystem; \`pyproject.toml\` declares no runtime dependencies and unpinned dev extras, so it never produced updates. Matches the reference github-actions-only file.
- \`minify.yml\`: the job only triggers on \`pull_request\`, so the \`workflow_dispatch\`/\`push\` branches of its \`if\` were dead; keep only the same-repo guard.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Standardized the repository’s GitHub configuration by removing inactive Python dependency updates and simplifying the minification workflow guard to match the reference configuration.

### 📊 Key Changes

- Removed the `pip` ecosystem entry from `.github/dependabot.yml`; GitHub Actions dependency updates remain enabled.
- Simplified `.github/workflows/minify.yml` to run only when a pull request originates from the same repository.
- Removed unreachable `workflow_dispatch` and `push` checks from the minification job condition.

### 🎯 Purpose & Impact

- Dependabot will no longer create Python dependency update pull requests for this repository.
- The minification job continues to handle eligible same-repository pull requests while excluding fork pull requests, which cannot receive pushed commits.