### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,10 +3,10 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📄 Docs
-    url: https://docs.ultralytics.com/
+    url: https://docs.ultralytics.com
     about: Full Ultralytics Documentation
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,5 +12,5 @@ contact_links:
     url: https://ultralytics.com/discord
     about: Ask on Ultralytics Discord
   - name: ⌨️ Reddit
-    url: https://reddit.com/r/ultralytics
+    url: https://www.reddit.com/r/ultralytics/
     about: Ask on Ultralytics Subreddit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # 🚀 Ultralytics LLM
 
@@ -10,8 +10,8 @@
 [![jsDelivr hits](https://data.jsdelivr.com/v1/package/gh/ultralytics/llm/badge?style=rounded)](https://www.jsdelivr.com/package/gh/ultralytics/llm)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 ![Ultralytics Chat Window](https://github.com/user-attachments/assets/a5e02018-b0df-4366-939d-402bbbd234f2)
 
@@ -286,7 +286,7 @@ Ultralytics thrives on community collaboration! While this repo is currently exp
 - **Bug Reports**: Found an issue? Report it on [GitHub Issues](https://github.com/ultralytics/llm/issues)
 - **Feature Requests**: Have an idea? Share it via [GitHub Issues](https://github.com/ultralytics/llm/issues)
 - **Pull Requests**: Want to contribute? Please read our [Contributing Guide](https://docs.ultralytics.com/help/contributing) first
-- **Feedback**: Share your experience in our [Discord](https://discord.com/invite/ultralytics) or [Community Forums](https://community.ultralytics.com/)
+- **Feedback**: Share your experience in our [Discord](https://discord.com/invite/ultralytics) or [Community Forums](https://community.ultralytics.com)
 
 A heartfelt thank you 🙏 to all our contributors!
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -127,7 +127,7 @@ Request body:
     ],
     "session_id": "optional-session-id",
     "context": {
-        "url": "https://docs.ultralytics.com/models/yolov9/",
+        "url": "https://docs.ultralytics.com/models/yolov9",
         "title": "YOLOv9: A Leap Forward in Object Detection Technology",
         "description": "Meta description value",
         "path": "/models/yolov9/"
@@ -147,7 +147,7 @@ Response stream (SSE):
 ```
 data: {"content": "You're on the Ultralytics docs page: "}
 data: {"content": "\"YOLOv9: A Leap Forward in Object Detection Technology\" — "}
-data: {"content": "URL: https://docs.ultralytics.com/models/yolov9/"}
+data: {"content": "URL: https://docs.ultralytics.com/models/yolov9"}
 data: [DONE]
 ```
 
@@ -170,7 +170,7 @@ Response:
     "results": [
         {
             "title": "Training Configuration",
-            "url": "https://docs.ultralytics.com/usage/training/",
+            "url": "https://docs.ultralytics.com/usage/training",
             "text": "Step-by-step instructions for configuring Ultralytics training jobs…",
             "score": 0.95
         }


### PR DESCRIPTION
## Summary
- Removed 8 terminating path slashes from Ultralytics URLs across 3 source files.
- Refreshed 2 occurrences of the genuine permanent `reddit.com` to `www.reddit.com` redirect.

## Judgment
- Manually reviewed every changed URL in context.
- Preserved URL-encoded badge parameters and intentional Ultralytics vanity links.
- Rejected redirects: none.
- Dead links: none.

## Validation
- Shared normalizer positive/negative tests passed.
- Rescan found zero eligible trailing slashes.
- Redirect rescan proposed zero further changes after all occurrences were reconciled.
- Issue-template YAML parsed successfully with Ruby YAML.
- Direct serial request to the lowercase canonical Reddit URL returned HTTP 200 without a redirect.
- `python -m pytest tests -q`: 4 passed.
- `git diff --check` passed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Ultralytics documentation, forum, website, and Reddit URLs to use the reviewed canonical forms, including removing unnecessary trailing slashes and switching Reddit links to `www.reddit.com`.

### 📊 Key Changes

- Removed trailing slashes from documentation, community forum, main website, and API example URLs.
- Updated Reddit links in the issue template and README from `reddit.com` to `www.reddit.com`, retaining the subreddit path slash.
- Applied the URL updates across `.github/ISSUE_TEMPLATE/config.yml`, `README.md`, and `docs/API.md`.
- Preserved URL-encoded badge parameters and intentional vanity links.

### 🎯 Purpose & Impact

- Links and API examples now consistently use the reviewed canonical URL forms.
- The issue template and README direct users to the `www.reddit.com/r/ultralytics/` community URL.
- No functional application behavior changed.